### PR TITLE
Better example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ A static page has 3 simple fields: `name`, `slug` and `content`. On top of that,
   {% block title %}
     {% override_title object default=object.name %}
   {% endblock %}
-  
+
   {% block extrahead %}
     {% override_description my_page default='' %}
     {% block_indexing my_page default=False %}
   {% endblock %}
-  
+
   {% block  content %}
     {{ object.rendered_content }}
   {% endblock content %}


### PR DESCRIPTION
Janek dodawał apkę do RODO i użył oczywiście przykładowego kodu z README - który jednak nie robi tego co najrozsądniejsze, czyli zamiast ustawiać jako domyślny tytuł strony jej nazwę, ustawia jako domyślny tytuł wszystkich stron test "My title". Pomija też inne opcje SEO, które w ten sposób zostają martwe w adminie i wprowadzają w błąd.